### PR TITLE
Fix iOS VoiceOver so that --exposure updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,13 +171,20 @@ class ImageCompare extends HTMLElement {
   connectedCallback() {
     this.shadowRoot.appendChild(template.content.cloneNode(true));
     
-    this.shadowRoot.querySelector("input").addEventListener('input', ({ target }) => {
-      if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
+    ['input', 'change'].forEach((eventName) => {
+      this.shadowRoot.querySelector("input").addEventListener(
+        eventName,
+        ({ target }) => {
+          if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
 
-      this.animationFrame = requestAnimationFrame(() => {
-        this.shadowRoot.host.style.setProperty('--exposure', `${target.value}%`)
-      });
+          this.animationFrame = requestAnimationFrame(() => {
+            this.shadowRoot.host.style.setProperty('--exposure', `${target.value}%`)
+          });
+        },
+      );
     });
+    this.shadowRoot.querySelector("input").addEventListener('input', handleChange);
+    this.shadowRoot.querySelector("input").addEventListener('change', handleChange);
 
     const customLabel = this.shadowRoot.host.getAttribute('label-text');
     if(customLabel) {

--- a/src/index.js
+++ b/src/index.js
@@ -183,8 +183,6 @@ class ImageCompare extends HTMLElement {
         },
       );
     });
-    this.shadowRoot.querySelector("input").addEventListener('input', handleChange);
-    this.shadowRoot.querySelector("input").addEventListener('change', handleChange);
 
     const customLabel = this.shadowRoot.host.getAttribute('label-text');
     if(customLabel) {


### PR DESCRIPTION
iOS VoiceOver with Safari (tested on iOS 15.1) has special gestures when it's virtual cursor is on a slider, you can swipe up/down to increment/decrement the slider. In this case, the input's "input" event does not fire, it only receives "change" after each gesture. This change simply listens for the "change" event too.

This also fixes macOS VoiceOver's interaction if you interact entirely with its virtual cursor (probably uncommon, you have to use SHIFT + VO + DOWN to move cursor to the slider thumb, then VO + LEFT/RIGHT to increment/decrement).

Note that iOS VoiceOver and Android Talkback both support a double-tap-then-hold, wait, then drag gesture to directly manipulate sliders. That fires "input" events. Both have issues announcing progress while dragging and when finished dragging (for Talkback, the issue is with https://bugs.chromium.org/p/chromium/issues/detail?id=1272107), but those are issues with the native range input.