### PR TITLE
Fix JS error in iOS13 and below

### DIFF
--- a/manifests/manifest-vscode.json
+++ b/manifests/manifest-vscode.json
@@ -3,7 +3,7 @@
   "tags": [
     {
       "name": "image-compare",
-      "description": "Our ImageCompare web component class\n\nSlots:\n\n  * `image-1` {} - Your first image. Will appear on the \"left\"\n\n  * `image-2` {} - Your second image. Will appear on the \"right\"\n\nAttributes:\n\n  * `label-text` {string} - Provide additional context to screen reader users.\n\nProperties:\n\n  * `animationFrame` - ",
+      "description": "Our ImageCompare web component class\n\nSlots:\n\n  * `image-1` {} - Your first image. Will appear on the \"left\"\n\n  * `image-2` {} - Your second image. Will appear on the \"right\"\n\nAttributes:\n\n  * `label-text` {string} - Provide additional context to screen reader users.",
       "attributes": [
         {
           "name": "label-text",

--- a/manifests/manifest.json
+++ b/manifests/manifest.json
@@ -12,11 +12,6 @@
           "type": "string"
         }
       ],
-      "properties": [
-        {
-          "name": "animationFrame"
-        }
-      ],
       "slots": [
         {
           "name": "image-1",

--- a/manifests/manifest.md
+++ b/manifests/manifest.md
@@ -8,12 +8,6 @@ Our ImageCompare web component class
 |--------------|----------|--------------------------------------------------|
 | `label-text` | `string` | Provide additional context to screen reader users. |
 
-## Properties
-
-| Property         |
-|------------------|
-| `animationFrame` |
-
 ## Slots
 
 | Name      | Description                                   |

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const thumbSvgWidth = 4;
 
 // Since the code below is a template string literal, it will not be minified or
 // transpiled
-template.innerHTML = /*html*/`
+template.innerHTML = /*html*/ `
   <style>
     :host {
       --exposure: 50%;
@@ -141,19 +141,19 @@ template.innerHTML = /*html*/`
 
 /**
  * Our ImageCompare web component class
- * 
+ *
  * @attr {string} label-text - Provide additional context to screen reader users.
- * 
+ *
  * @slot image-1 - Your first image. Will appear on the "left"
  * @slot image-2 - Your second image. Will appear on the "right"
- * 
- * @cssprop --thumb-background-color - The background color of the range slider handle. 
+ *
+ * @cssprop --thumb-background-color - The background color of the range slider handle.
  * @cssprop --thumb-background-image - The background image of the range slider handle.
  * @cssprop --thumb-size - The size of the range slider handle.
  * @cssprop --thumb-radius - The border-radius of the range slider handle.
  * @cssprop --thumb-border-color - The color of the range slider handle border.
  * @cssprop --thumb-border-size - The width of the range slider handle border.
- * 
+ *
  * @ccprop --focus-width - The width of the range slider handle's focus outline.
  * @ccprop --focus-color - The color of the range slider handle's focus outline.
  *
@@ -166,26 +166,26 @@ class ImageCompare extends HTMLElement {
     this.attachShadow({ mode: "open" });
   }
 
-  animationFrame;
-
   connectedCallback() {
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-    
-    ['input', 'change'].forEach((eventName) => {
-      this.shadowRoot.querySelector("input").addEventListener(
-        eventName,
-        ({ target }) => {
+
+    ["input", "change"].forEach((eventName) => {
+      this.shadowRoot
+        .querySelector("input")
+        .addEventListener(eventName, ({ target }) => {
           if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
 
           this.animationFrame = requestAnimationFrame(() => {
-            this.shadowRoot.host.style.setProperty('--exposure', `${target.value}%`)
+            this.shadowRoot.host.style.setProperty(
+              "--exposure",
+              `${target.value}%`
+            );
           });
-        },
-      );
+        });
     });
 
-    const customLabel = this.shadowRoot.host.getAttribute('label-text');
-    if(customLabel) {
+    const customLabel = this.shadowRoot.host.getAttribute("label-text");
+    if (customLabel) {
       this.shadowRoot.querySelector(".js-label-text").textContent = customLabel;
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const thumbSvgWidth = 4;
 
 // Since the code below is a template string literal, it will not be minified or
 // transpiled
-template.innerHTML = /*html*/ `
+template.innerHTML = /*html*/`
   <style>
     :host {
       --exposure: 50%;
@@ -141,19 +141,19 @@ template.innerHTML = /*html*/ `
 
 /**
  * Our ImageCompare web component class
- *
+ * 
  * @attr {string} label-text - Provide additional context to screen reader users.
- *
+ * 
  * @slot image-1 - Your first image. Will appear on the "left"
  * @slot image-2 - Your second image. Will appear on the "right"
- *
- * @cssprop --thumb-background-color - The background color of the range slider handle.
+ * 
+ * @cssprop --thumb-background-color - The background color of the range slider handle. 
  * @cssprop --thumb-background-image - The background image of the range slider handle.
  * @cssprop --thumb-size - The size of the range slider handle.
  * @cssprop --thumb-radius - The border-radius of the range slider handle.
  * @cssprop --thumb-border-color - The color of the range slider handle border.
  * @cssprop --thumb-border-size - The width of the range slider handle border.
- *
+ * 
  * @ccprop --focus-width - The width of the range slider handle's focus outline.
  * @ccprop --focus-color - The color of the range slider handle's focus outline.
  *
@@ -168,24 +168,22 @@ class ImageCompare extends HTMLElement {
 
   connectedCallback() {
     this.shadowRoot.appendChild(template.content.cloneNode(true));
-
-    ["input", "change"].forEach((eventName) => {
-      this.shadowRoot
-        .querySelector("input")
-        .addEventListener(eventName, ({ target }) => {
+    
+    ['input', 'change'].forEach((eventName) => {
+      this.shadowRoot.querySelector("input").addEventListener(
+        eventName,
+        ({ target }) => {
           if (this.animationFrame) cancelAnimationFrame(this.animationFrame);
 
           this.animationFrame = requestAnimationFrame(() => {
-            this.shadowRoot.host.style.setProperty(
-              "--exposure",
-              `${target.value}%`
-            );
+            this.shadowRoot.host.style.setProperty('--exposure', `${target.value}%`)
           });
-        });
+        },
+      );
     });
 
-    const customLabel = this.shadowRoot.host.getAttribute("label-text");
-    if (customLabel) {
+    const customLabel = this.shadowRoot.host.getAttribute('label-text');
+    if(customLabel) {
       this.shadowRoot.querySelector(".js-label-text").textContent = customLabel;
     }
   }


### PR DESCRIPTION
Earlier versions of iOS throw errors when a class has uninitialized class properties

@tedw reported this bug and provided a fix. This has been tested and confirmed to work.

Thanks @tedw!

Fixes #15