### PR TITLE
Fix @ccprop typo hiding four CSS properties from the docs

### DIFF
--- a/manifests/manifest.json
+++ b/manifests/manifest.json
@@ -46,6 +46,22 @@
         {
           "name": "--thumb-border-size",
           "description": "The width of the range slider handle border."
+        },
+        {
+          "name": "--focus-width",
+          "description": "The width of the range slider handle's focus outline."
+        },
+        {
+          "name": "--focus-color",
+          "description": "The color of the range slider handle's focus outline."
+        },
+        {
+          "name": "--divider-width",
+          "description": "The width of the divider shown between the two images."
+        },
+        {
+          "name": "--divider-color",
+          "description": "The color of the divider shown between the two images."
         }
       ]
     }

--- a/manifests/manifest.md
+++ b/manifests/manifest.md
@@ -19,6 +19,10 @@ Our ImageCompare web component class
 
 | Property                   | Description                                      |
 |----------------------------|--------------------------------------------------|
+| `--divider-color`          | The color of the divider shown between the two images. |
+| `--divider-width`          | The width of the divider shown between the two images. |
+| `--focus-color`            | The color of the range slider handle's focus outline. |
+| `--focus-width`            | The width of the range slider handle's focus outline. |
 | `--thumb-background-color` | The background color of the range slider handle. |
 | `--thumb-background-image` | The background image of the range slider handle. |
 | `--thumb-border-color`     | The color of the range slider handle border.     |

--- a/src/index.js
+++ b/src/index.js
@@ -154,11 +154,11 @@ template.innerHTML = /*html*/`
  * @cssprop --thumb-border-color - The color of the range slider handle border.
  * @cssprop --thumb-border-size - The width of the range slider handle border.
  * 
- * @ccprop --focus-width - The width of the range slider handle's focus outline.
- * @ccprop --focus-color - The color of the range slider handle's focus outline.
+ * @cssprop --focus-width - The width of the range slider handle's focus outline.
+ * @cssprop --focus-color - The color of the range slider handle's focus outline.
  *
- * @ccprop --divider-width - The width of the divider shown between the two images.
- * @ccprop --divider-color - The color of the divider shown between the two images.
+ * @cssprop --divider-width - The width of the divider shown between the two images.
+ * @cssprop --divider-color - The color of the divider shown between the two images.
  */
 class ImageCompare extends HTMLElement {
   constructor() {

--- a/test/build/manifests.test.js
+++ b/test/build/manifests.test.js
@@ -44,12 +44,23 @@ describe("npm run document", () => {
   // they can theme it. If the analyzer stops picking those tags up, the promise
   // silently disappears from the editor autocomplete that reads this manifest.
   it("documents every CSS custom property tagged in the source", () => {
-    const tagged = [...source.matchAll(/@cssprop\s+(--[\w-]+)/g)].map(
+    const tagged = [...source.matchAll(/@cssprop(?:erty)?\s+(--[\w-]+)/gi)].map(
       ([, name]) => name,
     );
     const documented = tag.cssProperties.map(({ name }) => name);
 
     expect(tagged.filter((name) => !documented.includes(name))).toEqual([]);
+  });
+
+  // The test above can only check tags the analyzer would recognize, so a
+  // misspelled one is invisible to it — the property just quietly vanishes from
+  // the docs. `@cssprop` and `@cssproperty` are the two spellings that work.
+  it("spells every CSS property tag the way the analyzer expects", () => {
+    const misspelled = [...source.matchAll(/@(\w*prop\w*)/g)]
+      .map(([, name]) => name)
+      .filter((name) => !["cssprop", "cssproperty"].includes(name.toLowerCase()));
+
+    expect([...new Set(misspelled)]).toEqual([]);
   });
 
   it("gives every documented item a description", () => {


### PR DESCRIPTION
## Overview

Four of the component's themeable custom properties — `--focus-width`, `--focus-color`, `--divider-width`, and `--divider-color` — were tagged `@ccprop` instead of `@cssprop` in the source JSDoc. `web-component-analyzer` doesn't recognize that spelling, so it skipped them entirely. The properties have worked all along and consumers can set them today, but they never showed up in the published documentation, and editors reading `manifest-vscode.json` wouldn't autocomplete them. This corrects the four tags and regenerates the manifests, which adds the missing entries to `manifest.json` and `manifest.md`.

The manifest test added in #129 checks that every property tagged `@cssprop` in the source reaches the manifest — so it covered the four recovered properties automatically, with no changes needed. But that framing means it could never have caught this bug in the first place: a misspelled tag is invisible to a test that only looks at correctly spelled ones. So this also adds a companion test that rejects any `@…prop…` tag the analyzer wouldn't recognize, which fails with the offending spelling named. `@cssprop` and `@cssproperty` are both accepted, since the analyzer honors both.

## Screenshots

## Testing

- [ ] Check out this branch, run `npm ci`, then `npm test` — 54 tests should pass
- [ ] Open `manifests/manifest.md` and confirm the CSS Custom Properties table now lists ten rows, including `--divider-color`, `--divider-width`, `--focus-color`, and `--focus-width`
- [ ] In `src/index.js`, change one `@cssprop` back to `@ccprop` and run `npm test` — a test should fail saying the tag isn't spelled the way the analyzer expects, naming `ccprop`. Revert the change.
- [ ] Run `npm start` and open the demo page — this is a documentation-only change, so the component should look and behave exactly as it does on `main`

---

Closes #130