### PR TITLE
Remove stray top-level prepare key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "homepage": "https://image-compare-component.netlify.app/",
   "main": "dist/index.js",
-  "prepare": "npm run prepare",
   "files": [
     "dist",
     "manifests"


### PR DESCRIPTION
## Overview

`package.json` carried a `prepare` key at the top level, outside the `scripts` block. npm only reads lifecycle scripts from `scripts`, so it never ran — the real `scripts.prepare` is what executes on install and publish, and it's correct. The problem is that the stray key is self-referential (`"prepare": "npm run prepare"`), so anyone who noticed it and "fixed" it by moving it into `scripts` would have replaced a working build script with an infinite loop. Deleting it removes that trap.

Since the whole claim here is that the key was inert, I confirmed it rather than assuming: `npm pack --dry-run` lists the same nine files before and after, and the `prepare` lifecycle still runs the build and doc generation as it did.

## Screenshots

## Testing

- [ ] Check out this branch and run `npm ci` — installation should complete normally, running the build and generating the manifests along the way
- [ ] Run `npm test` — 53 tests should pass
- [ ] Run `npm run prepare` on its own — it should build `dist/` and regenerate `manifests/`, then exit rather than looping

---

Closes #131